### PR TITLE
Keep Okteto pipeline awake

### DIFF
--- a/.github/workflows/okteto-keep-awake.yml
+++ b/.github/workflows/okteto-keep-awake.yml
@@ -17,7 +17,7 @@ jobs:
       - name: "Activate Namespace"
         uses: okteto/namespace@latest
         with:
-          name: mathielo
+          namespace: mathielo
       - name: "Trigger the pipeline"
         uses: okteto/pipeline@latest
         with:

--- a/.github/workflows/okteto-keep-awake.yml
+++ b/.github/workflows/okteto-keep-awake.yml
@@ -2,10 +2,8 @@
 # by default, if no interaction happens within 24 hours, the instance will automatically be put to sleep
 name: "Okteto keep awake"
 on:
-  [push]
-
-  # schedule:
-  #   - cron: "* * * * *"
+  schedule:
+    - cron: "* 5 * * *"
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/okteto-keep-awake.yml
+++ b/.github/workflows/okteto-keep-awake.yml
@@ -1,0 +1,24 @@
+# this is a workaround to prevent the Okteto's free tier instance from sleeping
+# by default, if no interaction happens within 24 hours, the instance will automatically be put to sleep
+name: "Okteto keep awake"
+on:
+  [push]
+
+  # schedule:
+  #   - cron: "* * * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: context
+        uses: okteto/context@latest
+        with:
+          token: ${{ secrets.OKTETO_TOKEN }}
+      - name: "Activate Namespace"
+        uses: okteto/namespace@latest
+        with:
+          name: mathielo
+      - name: "Trigger the pipeline"
+        uses: okteto/pipeline@latest
+        with:
+          name: fasd-bot


### PR DESCRIPTION
## Context
FASD Bot is currently hosted on Okteto's Free Tier plan, whose instances only remain alive for 24 hours if no interaction happens with Okteto. According to the [pricing page](https://www.okteto.com/pricing), there are three interactions that are considered:
- Upgrade or Redeploy it via the UI or the command line
- Launched a Developer Environment with okteto up
- Pushed the latest version of your code with okteto push

## Solution
My initial idea is to set up a Github Action scheduled job to trigger the deployment once a day. It's still not clear if this will work just yet, but this feels like something that could potentially do it 🙂 

## What has changed?
I've added a new GA workflow that will trigger the deployment of the existing Okteto pipeline every day at 5 am.

Some preliminary tests have been done in this PR and everything seems to be working.