### PR TITLE
Make message text check nil-safe

### DIFF
--- a/src/fasd_bot/main.rb
+++ b/src/fasd_bot/main.rb
@@ -18,7 +18,7 @@ puts "Using [#{Config::STICKER_COLLECTION_NAME}] sticker collection"
 
 Telegram::Bot::Client.run(Config::TELEGRAM_TOKEN, timeout: 60) do |bot|
   bot.listen do |message|
-    next unless message.text
+    next unless message&.text
 
     HANDLERS.each do |handler|
       begin


### PR DESCRIPTION
## Context
While making some improvements to Okteto's deployment pipeline I've noticed the app is currently crashing while checking whether the message text is valid or not.

Reference:
![image](https://user-images.githubusercontent.com/8050903/158612714-de6e6044-f7e2-47dd-accc-72009794134a.png)

Seems like, for some reason, the message variable is coming with a nil value in this context.

## Solution
I've added the safe navigation operator (&) to the call. This should fix the issue.